### PR TITLE
feat: Add Entra authorisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dstew-access-api/generated
 *.iws
 *.iml
 *.ipr
+*.run.xml
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/dstew-access-service/build.gradle
+++ b/dstew-access-service/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation('org.springframework.boot:spring-boot-starter-web') {
         exclude group: 'com.google.code.gson', module: 'gson'
@@ -39,6 +41,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
     implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs:3.3.1"
+
+    // Spring Boot Starter for Microsoft Entra (provides auto-configuration specific to Entra)
+    implementation 'com.azure.spring:spring-cloud-azure-starter-active-directory:5.22.0'
 
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'

--- a/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/NoSecurityConfig.java
+++ b/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/NoSecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -21,7 +22,9 @@ class NoSecurityConfig {
    */
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+    http
+            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+            .csrf(AbstractHttpConfigurer::disable);
     return http.build();
   }
 }

--- a/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/NoSecurityConfig.java
+++ b/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/NoSecurityConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.justice.laa.dstew.access.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security configuration if security is disabled (e.g. for development).
+ */
+@ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "false")
+@Configuration
+class NoSecurityConfig {
+  /**
+   * Return the security filter chain.
+   *
+   * @param http Used to configure web security.
+   * @return The built security configuration.
+   * @throws Exception if anything went wrong.
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+    return http.build();
+  }
+}

--- a/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/SecurityConfig.java
+++ b/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -29,14 +30,12 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
-            .with(AadResourceServerHttpSecurityConfigurer.aadResourceServer(),
-                    withDefaults())
-            .authorizeHttpRequests(auth -> auth
+            .with(AadResourceServerHttpSecurityConfigurer.aadResourceServer(), withDefaults())
+            .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated())
-            .oauth2ResourceServer(oauth2 -> oauth2
-                    .jwt(withDefaults()));
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(withDefaults()))
+            .csrf(AbstractHttpConfigurer::disable);
     return http.build();
   }
 }
-

--- a/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/SecurityConfig.java
+++ b/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package uk.gov.justice.laa.dstew.access.config;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import com.azure.spring.cloud.autoconfigure.implementation.aad.security.AadResourceServerHttpSecurityConfigurer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security configuration if security is enabled.
+ */
+@ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "true")
+@Configuration
+@EnableMethodSecurity
+@EnableWebSecurity
+public class SecurityConfig {
+  /**
+   * Return the security filter chain.
+   *
+   * @param http Used to configure web security.
+   * @return The built security configuration.
+   * @throws Exception if anything went wrong.
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+            .with(AadResourceServerHttpSecurityConfigurer.aadResourceServer(),
+                    withDefaults())
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2
+                    .jwt(withDefaults()));
+    return http.build();
+  }
+}
+

--- a/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
+++ b/dstew-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
@@ -18,6 +18,8 @@ import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.diff.Diff;
 import org.javers.core.diff.changetype.ValueChange;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.dstew.access.config.SqsProducer;
 import uk.gov.justice.laa.dstew.access.entity.ApplicationEntity;
@@ -84,6 +86,7 @@ public class ApplicationService {
    *
    * @return the list of applications
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Read') or hasAuthority('APPROLE_ApplicationReader')")
   public List<Application> getAllApplications() {
     return applicationRepository.findAll().stream().map(applicationMapper::toApplication).toList();
   }
@@ -94,6 +97,7 @@ public class ApplicationService {
    * @param id the application id
    * @return the requested application
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Read') or hasAuthority('APPROLE_ApplicationReader')")
   public Application getApplication(UUID id) {
     ApplicationEntity applicationEntity = checkIfApplicationExists(id);
     return applicationMapper.toApplication(applicationEntity);
@@ -105,6 +109,7 @@ public class ApplicationService {
    * @param applicationRequestBody the application to be created
    * @return the id of the created application
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Write') or hasAuthority('APPROLE_ApplicationWriter')")
   public UUID createApplication(ApplicationRequestBody applicationRequestBody) {
     ApplicationEntity applicationEntity =
         applicationMapper.toApplicationEntity(applicationRequestBody);
@@ -130,6 +135,7 @@ public class ApplicationService {
    * @param id the unique identifier of the application.
    * @param requestBody the DTO containing the change.
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Write') or hasAuthority('APPROLE_ApplicationWriter')")
   public void updateApplication(UUID id, ApplicationUpdateRequestBody requestBody) {
     ApplicationEntity applicationEntity = checkIfApplicationExists(id);
 
@@ -161,6 +167,7 @@ public class ApplicationService {
    *
    * @return the list of history for an application
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Read') or hasAuthority('APPROLE_ApplicationReader')")
   public List<ApplicationHistoryEntry> getAllApplicationHistory(UUID applicationId) {
     return applicationHistoryRepository.findByApplicationId(applicationId)
         .stream().map(applicationMapper::toApplicationHistoryEntry).toList();
@@ -190,6 +197,7 @@ public class ApplicationService {
    * @param applicationId unique identifier of the application.
    * @return the latest history for the application.
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Read') or hasAuthority('APPROLE_ApplicationReader')")
   public ApplicationHistoryEntry getApplicationsLatestHistory(UUID applicationId) {
     checkIfApplicationExists(applicationId);
 
@@ -208,6 +216,7 @@ public class ApplicationService {
    * @param applicationHistoryRequestBody the DTO containing the history.
    * @return a unique identifier for the history.
    */
+  @PreAuthorize("hasAuthority('SCOPE_Application.Write') or hasAuthority('APPROLE_ApplicationWriter')")
   public UUID createApplicationHistory(UUID applicationId, ApplicationHistoryRequestBody applicationHistoryRequestBody) {
 
     ApplicationHistoryEntity applicationHistoryEntity = new ApplicationHistoryEntity();

--- a/dstew-access-service/src/main/resources/application.yml
+++ b/dstew-access-service/src/main/resources/application.yml
@@ -30,11 +30,22 @@ spring:
       sqs:
         endpoint: http://localhost:4566
 
+    azure:
+      active-directory:
+        enabled: ${ENTRA_ENABLED:true}  # set ENTRA_ENABLED=false for development
+        profile:
+          tenant-id: ${ENTRA_TENANT_ID}
+        app-id-uri: ${ENTRA_APP_ID_URI}
+
 info:
   app:
     name: Access
     description: LAA Access Data Stewardship REST API
     version: 1.0.0
+
+logging:
+  level:
+    com.azure.spring: INFO
 
 management:
   endpoints:


### PR DESCRIPTION
- Add OAuth2 and Spring Security starters, and Azure AD (now Entra) starter
- Add Spring Security filterChain beans for security enabled and disabled
- Add PreAuthorize annotations to service methods with required permissions
- Update application configuration with Entra settings (from env vars)
- Add IDEA run configs to gitignore because they may contain secrets
- Disable CSRF protection in the security config, which is reasonable for a REST API that is never called from a web browser (and does not use session cookies for authentication)

references: DSTEW-19