### PR TITLE
ci: Add Build main workflow to build and publish main branch

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,26 +1,30 @@
-name: Build feature
+name: Build main
 
 on:
-  push:
-    branches-ignore:
-      - main
-      - 'feature-dev/*'
-      - 'feature-test/*'
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
 
 jobs:
-  build-and-publish-snapshot:
+  build-and-publish-release:
+    if: ${{ github.event.pull_request.merged == true }}
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
     permissions:
       contents: write
       packages: write
     with:
       integration_test_task: 'integrationTest'
-      publish_package: 'true'
-      is_snapshot: 'true'
+      create_tag: 'true'
       junit_results_path: 'dstew-access-service/build/test-results'
       junit_report_path: 'dstew-access-service/build/reports/tests'
       checkstyle_report_path: 'dstew-access-service/build/reports/checkstyle'
       jacoco_coverage_report: 'false'
       jacoco_coverage_report_path: 'dstew-access-service/build/reports/jacoco'
+      ### Let's see how github-actions-bot works for now.
+      #github_bot_username: 'laa-ccms-caab-service'
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
+      ### May need the following when creating a tag triggers downstream jobs.
+      #github_app_id: ${{ vars.LAA_CCMS_CAAB_SERVICE_APP_ID }}
+      #github_app_private_key: ${{ secrets.LAA_CCMS_CAAB_SERVICE_KEY }}
+      #github_app_organisation: 'ministryofjustice'


### PR DESCRIPTION
- Add new GitHub Actions workflow file that calls gradle build and publish common workflow when PRs closed in main branch
- Update workflow for feature branches to run integration tests

references: DSTEW-61