### PR TITLE
ci: Add publish to ECR and deploy with Helm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,14 +31,6 @@ updates:
       github-actions:
         patterns: [ "**" ]
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      docker:
-        patterns: [ "**" ]
-
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -20,14 +20,12 @@ jobs:
       checkstyle_report_path: 'dstew-access-service/build/reports/checkstyle'
       jacoco_coverage_report: 'false'
       jacoco_coverage_report_path: 'dstew-access-service/build/reports/jacoco'
-      ### Let's see how github-actions-bot works for now.
-      #github_bot_username: 'laa-ccms-caab-service'
+      github_bot_username: 'laa-data-stewardship'
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
-      ### May need the following when creating a tag triggers downstream jobs.
-      #github_app_id: ${{ vars.LAA_CCMS_CAAB_SERVICE_APP_ID }}
-      #github_app_private_key: ${{ secrets.LAA_CCMS_CAAB_SERVICE_KEY }}
-      #github_app_organisation: 'ministryofjustice'
+      github_app_id: ${{ secrets.GITHUBAPP_ID }}
+      github_app_private_key: ${{ secrets.GITHUBAPP_PRIVATE_KEY }}
+      github_app_organisation: 'ministryofjustice'
 
   vulnerability-report:
     if: ${{ github.event.pull_request.merged == true }}

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -1,0 +1,79 @@
+name: Deploy feature
+
+on:
+  push:
+    branches:
+      - 'feature-dev/**'
+      - 'feature-test/**'
+
+permissions:
+  contents: read
+
+jobs:
+  define-feature-version:
+    runs-on: ubuntu-latest
+    outputs:
+      feature_version: ${{ steps.get-feature-version.outputs.feature_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/remove-prefix@v1
+        id: get-feature-name
+        with:
+          string: ${{ github.ref_name }}
+          prefix: 'feature-*/'
+      - name: Get feature version
+        id: get-feature-version
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          echo "feature_version=${{ steps.get-feature-name.outputs.result }}-${COMMIT_HASH}-SNAPSHOT" >> $GITHUB_OUTPUT
+          echo "Feature version: ${{ steps.get-feature-name.outputs.result }}-${COMMIT_HASH}-SNAPSHOT"
+
+  build-and-publish-snapshot:
+    needs: [ define-feature-version ]
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
+    permissions:
+      contents: write
+      packages: write
+    with:
+      integration_test_task: "integrationTest --tests '*IntegrationTest'"
+      publish_package: 'true'
+      override_version: ${{ needs.define-feature-version.outputs.feature_version }}
+      junit_results_path: 'dstew-access-service/build/test-results'
+      junit_report_path: 'dstew-access-service/build/reports/tests'
+      checkstyle_report_path: 'dstew-access-service/build/reports/checkstyle'
+      jacoco_coverage_report: 'false'
+      jacoco_coverage_report_path: 'dstew-access-service/build/reports/jacoco'
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  ecr-publish-image:
+    needs: [ build-and-publish-snapshot ]
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/ecr-publish-image.yml@v1
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      image_version: ${{ format('{0}-{1}', vars.IMAGE_PREFIX, needs.build-and-publish-snapshot.outputs.published_artifact_version) }}
+      jar_subproject: 'dstew-access-service'
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      ecr_repository: ${{ vars.ECR_REPOSITORY }}
+      ecr_region: ${{ vars.ECR_REGION }}
+      ecr_role_to_assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+
+  update-helm-chart:
+    needs: [ ecr-publish-image ]
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/update-helm-chart.yml@v1
+    with:
+      helm_charts_repository: 'laa-data-stewardship-helm-charts'
+      helm_charts_branch: 'development'
+      service_name: 'laa-ccms-caab-service'
+      subchart_name: 'caab-api'
+      application_version: ${{ needs.ecr-publish-image.outputs.published_image_version }}
+      feature_branch: ${{ github.ref_name }}
+      github_bot_username: 'laa-data-stewardship'
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      github_app_id: ${{ vars.GITHUBAPP_ID }}
+      github_app_private_key: ${{ secrets.GITHUBAPP_PRIVATE_KEY }}
+      github_app_organisation: 'ministryofjustice'

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,56 @@
+name: Deploy main
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  assemble-and-publish:
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
+    permissions:
+      contents: write
+      packages: write
+    with:
+      build_command: 'assemble'
+      publish_package: 'true'
+      junit_results: 'false'
+      junit_report: 'false'
+      checkstyle_report: 'false'
+      jacoco_coverage_report: 'false'
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  ecr-publish-image:
+    needs: [ assemble-and-publish ]
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/ecr-publish-image.yml@v1
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      image_version: ${{ format('{0}-{1}', vars.IMAGE_PREFIX, needs.assemble-and-publish.outputs.published_artifact_version) }}
+      jar_subproject: 'dstew-access-service'
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      ecr_repository: ${{ vars.ECR_REPOSITORY }}
+      ecr_region: ${{ vars.ECR_REGION }}
+      ecr_role_to_assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+
+  update-helm-chart:
+    needs: [ ecr-publish-image ]
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/update-helm-chart.yml@v1
+    with:
+      helm_charts_repository: 'laa-data-stewardship-helm-charts'
+      helm_charts_branch: 'main' # no 'development' branch
+      service_name: 'laa-data-stewardship-shared'
+      subchart_name: 'laa-data-stewardship-access'
+      application_version: ${{ needs.ecr-publish-image.outputs.published_image_version }}
+      github_bot_username: 'laa-data-stewardship'
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      github_app_id: ${{ secrets.GITHUBAPP_ID }}
+      github_app_private_key: ${{ secrets.GITHUBAPP_PRIVATE_KEY }}
+      github_app_organisation: 'ministryofjustice'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,13 @@
+plugins {
+    id 'net.researchgate.release' version '3.1.0'
+}
+
 subprojects {
     group = 'uk.gov.justice.laa.dstew.access'
+
+    release {
+        tagTemplate = '$name-$version'
+    }
 
     // Force version of Checkstyle to one without CVEs to avoid Snyk complaints.
     afterEvaluate {

--- a/dstew-access-api/build.gradle
+++ b/dstew-access-api/build.gradle
@@ -16,6 +16,14 @@ dependencies {
     implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
 }
 
+publishing {
+    publications {
+        gpr(MavenPublication) {
+            from(components.java)
+        }
+    }
+}
+
 sourceSets.main.java.srcDirs += ['generated/src/main/java']
 
 checkstyleMain.exclude("*")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.0.0
 group=uk.gov.justice.laa
+version=0.0.1-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,13 +2,13 @@ pluginManagement {
     repositories {
         maven {
             name = "gitHubPackages"
-            url = 'https://maven.pkg.github.com/ministryofjustice/laa-ccms-spring-boot-common'
+            url = uri('https://maven.pkg.github.com/ministryofjustice/laa-ccms-spring-boot-common')
             credentials {
                 username = System.getenv("GITHUB_ACTOR")?.trim() ?: settings.ext.find('project.ext.gitPackageUser')
                 password = System.getenv("GITHUB_TOKEN")?.trim() ?: settings.ext.find('project.ext.gitPackageKey')
             }
         }
-        maven { url = "https://plugins.gradle.org/m2/" }
+        maven { url = uri("https://plugins.gradle.org/m2/") }
         gradlePluginPortal()
     }
 


### PR DESCRIPTION
- Remove Docker ecosystem from dependabot YAML as unused
- Add deploy-feature workflow triggered by feature-*/* branches
- Add release gradle plugin and its configuration per project
- Move to snapshot versioning in `gradle.properties`
- Use canonical uri() for URI references in `settings.gradle`
- Add references to GitHub App secrets for token action
- Add Deploy main workflow file
- Add GitHub Packages publication to API `build.gradle`

references: DSTEW-63