### PR TITLE
chore: Update laa-ccms-spring-boot-plugin to release version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ pluginManagement {
     }
 
     plugins {
-        id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.37-4e69bcd-SNAPSHOT'
+        id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.37'
     }
 }
 


### PR DESCRIPTION
references: DSTEW-63
